### PR TITLE
:seedling: Return Unknown condition for NewAggregateCondition when no…

### DIFF
--- a/util/conditions/v1beta2/aggregate.go
+++ b/util/conditions/v1beta2/aggregate.go
@@ -59,7 +59,11 @@ func (o *AggregateOptions) ApplyOptions(opts []AggregateOption) *AggregateOption
 // Additionally, it is possible to inject custom merge strategies using the CustomMergeStrategy option.
 func NewAggregateCondition[T Getter](sourceObjs []T, sourceConditionType string, opts ...AggregateOption) (*metav1.Condition, error) {
 	if len(sourceObjs) == 0 {
-		return nil, errors.New("sourceObjs can't be empty")
+		return &metav1.Condition{
+			Type:   sourceConditionType,
+			Status: metav1.ConditionUnknown,
+			Reason: NotYetReportedReason,
+		}, nil
 	}
 
 	aggregateOpt := &AggregateOptions{


### PR DESCRIPTION
… soureObjs provided

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->