### PR TITLE
:bug: Do not compute aggregate cluster conditions when no sourceObjs

### DIFF
--- a/internal/controllers/cluster/cluster_controller_status.go
+++ b/internal/controllers/cluster/cluster_controller_status.go
@@ -791,15 +791,6 @@ func setRollingOutCondition(ctx context.Context, cluster *clusterv1.Cluster, con
 		return
 	}
 
-	if controlPlane == nil && len(machinePools.Items)+len(machineDeployments.Items) == 0 {
-		v1beta2conditions.Set(cluster, metav1.Condition{
-			Type:   clusterv1.ClusterRollingOutV1Beta2Condition,
-			Status: metav1.ConditionFalse,
-			Reason: clusterv1.ClusterNotRollingOutV1Beta2Reason,
-		})
-		return
-	}
-
 	ws := make([]aggregationWrapper, 0, len(machinePools.Items)+len(machineDeployments.Items)+1)
 	if controlPlane != nil {
 		// control plane is considered only if it is reporting the condition (the contract does not require conditions to be reported)
@@ -813,6 +804,15 @@ func setRollingOutCondition(ctx context.Context, cluster *clusterv1.Cluster, con
 	}
 	for _, md := range machineDeployments.Items {
 		ws = append(ws, aggregationWrapper{md: &md})
+	}
+
+	if len(ws) == 0 {
+		v1beta2conditions.Set(cluster, metav1.Condition{
+			Type:   clusterv1.ClusterRollingOutV1Beta2Condition,
+			Status: metav1.ConditionFalse,
+			Reason: clusterv1.ClusterNotRollingOutV1Beta2Reason,
+		})
+		return
 	}
 
 	rollingOutCondition, err := v1beta2conditions.NewAggregateCondition(
@@ -862,15 +862,6 @@ func setScalingUpCondition(ctx context.Context, cluster *clusterv1.Cluster, cont
 		return
 	}
 
-	if controlPlane == nil && len(machinePools.Items)+len(machineDeployments.Items) == 0 {
-		v1beta2conditions.Set(cluster, metav1.Condition{
-			Type:   clusterv1.ClusterScalingUpV1Beta2Condition,
-			Status: metav1.ConditionFalse,
-			Reason: clusterv1.ClusterNotScalingUpV1Beta2Reason,
-		})
-		return
-	}
-
 	ws := make([]aggregationWrapper, 0, len(machinePools.Items)+len(machineDeployments.Items)+1)
 	if controlPlane != nil {
 		// control plane is considered only if it is reporting the condition (the contract does not require conditions to be reported)
@@ -890,6 +881,15 @@ func setScalingUpCondition(ctx context.Context, cluster *clusterv1.Cluster, cont
 			continue
 		}
 		ws = append(ws, aggregationWrapper{ms: &ms})
+	}
+
+	if len(ws) == 0 {
+		v1beta2conditions.Set(cluster, metav1.Condition{
+			Type:   clusterv1.ClusterScalingUpV1Beta2Condition,
+			Status: metav1.ConditionFalse,
+			Reason: clusterv1.ClusterNotScalingUpV1Beta2Reason,
+		})
+		return
 	}
 
 	scalingUpCondition, err := v1beta2conditions.NewAggregateCondition(
@@ -939,15 +939,6 @@ func setScalingDownCondition(ctx context.Context, cluster *clusterv1.Cluster, co
 		return
 	}
 
-	if controlPlane == nil && len(machinePools.Items)+len(machineDeployments.Items) == 0 {
-		v1beta2conditions.Set(cluster, metav1.Condition{
-			Type:   clusterv1.ClusterScalingDownV1Beta2Condition,
-			Status: metav1.ConditionFalse,
-			Reason: clusterv1.ClusterNotScalingDownV1Beta2Reason,
-		})
-		return
-	}
-
 	ws := make([]aggregationWrapper, 0, len(machinePools.Items)+len(machineDeployments.Items)+1)
 	if controlPlane != nil {
 		// control plane is considered only if it is reporting the condition (the contract does not require conditions to be reported)
@@ -967,6 +958,15 @@ func setScalingDownCondition(ctx context.Context, cluster *clusterv1.Cluster, co
 			continue
 		}
 		ws = append(ws, aggregationWrapper{ms: &ms})
+	}
+
+	if len(ws) == 0 {
+		v1beta2conditions.Set(cluster, metav1.Condition{
+			Type:   clusterv1.ClusterScalingDownV1Beta2Condition,
+			Status: metav1.ConditionFalse,
+			Reason: clusterv1.ClusterNotScalingDownV1Beta2Reason,
+		})
+		return
 	}
 
 	scalingDownCondition, err := v1beta2conditions.NewAggregateCondition(

--- a/util/conditions/v1beta2/aggregate_test.go
+++ b/util/conditions/v1beta2/aggregate_test.go
@@ -69,8 +69,10 @@ func TestAggregate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:          "Error if negative polarity conditions are misconfigured",
-			conditions:    [][]metav1.Condition{},
+			name: "Error if negative polarity conditions are misconfigured",
+			conditions: [][]metav1.Condition{
+				{{Type: clusterv1.ScalingUpV1Beta2Condition, Status: metav1.ConditionTrue, Reason: "Reason-1", Message: "Message-1"}},
+			},
 			conditionType: clusterv1.ScalingUpV1Beta2Condition,
 			options:       []AggregateOption{NegativePolarityConditionTypes{"foo"}}, // NegativePolarityConditionTypes if set must equal source condition
 			want:          nil,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

- also fixes util test case (with no conditions specified in the test case, the tested function errors out [because there are no sourceObjs](https://github.com/kubernetes-sigs/cluster-api/blob/3cfb41dee1dc16cb89ebf19e63bc3cd2c64afd34/util/conditions/v1beta2/aggregate_test.go#L430)) this doesnt appear to align with the description of the test case (and no `sourceObjs` behavior is already tested [here](https://github.com/kubernetes-sigs/cluster-api/blob/3cfb41dee1dc16cb89ebf19e63bc3cd2c64afd34/util/conditions/v1beta2/aggregate_test.go#L449)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11820

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->